### PR TITLE
style: clean up whitespace in python scripts

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -4,7 +4,7 @@ import discord
 import requests
 from github import Github, Auth
 from discord.ext import commands
-from dotenv import load_dotenv 
+from dotenv import load_dotenv
 import difflib
 import asyncio
 import time
@@ -25,7 +25,7 @@ github = Github(auth = Auth.Token(GIT_TOKEN))
 
 user = github.get_user()
 repo = user.get_repo("dm_open_ref")
-	
+
 intents=discord.Intents.default()
 intents.message_content = True
 bot = commands.Bot(command_prefix="?o", intents = intents)
@@ -42,7 +42,7 @@ def check_rate_limit():
 		'Accept': 'application/vnd.github.v3+json'
 	}
 	response = requests.get('https://api.github.com/rate_limit', headers=headers)
-	
+
 	if response.status_code == 200:
 		rate_limit_info = response.json()
 		remaining = rate_limit_info['rate']['remaining']
@@ -72,7 +72,7 @@ async def send_commit_message(commit):
 	commit_message = commit['commit']['message']
 	author = commit['commit']['author']['name']
 	commit_url = commit['html_url']
- 
+
 	embed = discord.Embed(
 		title="Update to Open Ref!",
 		url=commit_url,
@@ -115,8 +115,8 @@ async def periodic_commit_check():
 	while not bot.is_closed():
 		await check_for_new_commits()
 		await asyncio.sleep(3600)
-  
-  
+
+
 '''
 Bot queries stuff
 '''
@@ -151,35 +151,35 @@ web_connection_status : str = ping_via_http(REPO)
 
 @bot.event
 async def on_ready():
-	
+
 	custom_activity = discord.Activity(
-		type=discord.ActivityType.custom, 
+		type=discord.ActivityType.custom,
 		state="Lummox has me locked up!"
 	)
-	
+
 	await bot.change_presence(status=discord.Status.online, activity=custom_activity)
 	print(f"\n{bot.user} is online")
 	await bot.sync_commands()
-		
+
 class MyView(discord.ui.View):
 	def __init__(self, ref_text = "", timeout_time=120):
 		super().__init__(timeout = timeout_time)
 		self.ref_text = ref_text
-		
+
 	@discord.ui.button(label="Click to View", style=discord.ButtonStyle.primary)
 	async def button_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
 		await interaction.response.send_message(self.ref_text, ephemeral=True, embed=None)
-  
+
 def clean_query(filename, replace_with=""):
 	# Define illegal characters based on the operating system
 	illegal_chars = '\\/*?:"<>|'
-	
+
 	# Build the cleaned filename by replacing illegal characters
 	cleaned = ''.join(char if char not in illegal_chars else replace_with for char in filename)
-	
+
 	return cleaned
 
-def special_characters(text) -> str: 
+def special_characters(text) -> str:
 	'''
 		Strips illegal characters from file names
 		Also performs minor cleanup of the file name
@@ -214,7 +214,7 @@ async def ncourage(ctx, *, user_input = None, user: discord.User = None):
 		username = user_input or ctx.author.name
 	messages = [f"You can do it, {username}", f"Go gettem, {username}", f"I believe in you, {username}"]
 	await ctx.send(random.choice(messages))
- 
+
 @bot.command(
 	brief="Spread the word of the best of the pokemon",
 	help="Sends a random Magikarp gif"
@@ -227,7 +227,7 @@ async def karp(ctx):
 async def brr(ctx, *, wat_brr):
 	print(wat_brr)
 	await ctx.send(f"{wat_brr} go brr")
- 
+
 @bot.command(
 	brief="Blessings!",
 	help="Blessings bestowed upon thee!"
@@ -235,7 +235,7 @@ async def brr(ctx, *, wat_brr):
 async def bless(ctx):
 	print("bless")
 	await ctx.send(f"https://media1.tenor.com/m/8Xlj8cg9L5EAAAAd/god-bless.gif")
- 
+
 @bot.command(
 	brief="hugs!",
 	help="send a hug gif"
@@ -243,7 +243,7 @@ async def bless(ctx):
 async def hug(ctx):
 	print("hug")
 	await ctx.send(f"https://tenor.com/bf6qM.gif")
- 
+
 @bot.command(
 	brief="Punish Oref!",
 	help="o-ref has been naughty!  Let the bot know by punishing it!"
@@ -252,7 +252,7 @@ async def bad(ctx):
 	print("bad bot")
 	messages = ["I've been a naughty bot", f"Please don't spank me again!", "So sorry.  I'll do better.", "I'm just glad that you noticed me", "If you don't like it, fix it!"]
 	await ctx.send(random.choices(messages)[0])
- 
+
 @bot.command(
 	brief="greetings!",
 	help="salutations!"
@@ -269,7 +269,7 @@ async def good(ctx):
 	print("good bot")
 	messages = ["Thank you!", f"I exist to please", "You're welcome", "I'm just glad that you noticed me", "I'm glad you like me", "Why are you talking to me?"]
 	await ctx.send(random.choices(messages)[0])
- 
+
 @bot.command(
 	brief="Sends Praise!",
 	help="(Usually) sends praise towards whomever you tag, or yourself if you don't specify."
@@ -286,7 +286,7 @@ async def praise(ctx, *, user_input = None, user: discord.User = None):
 	brief="Displays a reference file",
 	help="""Searches reference files on open-ref using your input.
 			It will first search file names and paths, and if no matches are found, it will search file contents.
-	   		It displays the best match to your search."""
+			It displays the best match to your search."""
 	)
 async def ref(ctx, *, query="DM"):
 	print(f"{ctx.guild}: {query}")
@@ -294,7 +294,7 @@ async def ref(ctx, *, query="DM"):
 	SEARCH_URL = "https://api.github.com/search/code"
 
 	headers = {'Authorization': f'Token {GIT_TOKEN}'}
- 
+
 	if query in OVERRIDE_QUERIES:
 		match = OVERRIDE_QUERIES[query]
 	#	await ctx.send(f"Override Query: {query} : {match}")
@@ -338,17 +338,17 @@ async def search(ctx, query, url, header, params):
 			unsorted_items = []
 			for item in search_results['items']:
 				unsorted_items.append(item['path'])
-	
+
 			print(f"Pre-Sort:\n{[unsorted_items]}")
 
 			if len(unsorted_items) > 0:
 				match = unsorted_items[0]
 
 				sorted_items = difflib.get_close_matches(query, [item for item in unsorted_items], n = len(unsorted_items), cutoff=0.33)
-	
+
 				if len(sorted_items) > 0:
 					match = sorted_items[0]
-		
+
 					print(f"Sorted:\n{[sorted_items]}")
 
 				page = get_page(match)
@@ -371,12 +371,12 @@ async def ref_info(ctx, content):
 		timeout = 300
 		ref_view = MyView(ref_content, timeout)
 		bot_message = await ctx.send(embed=prettify(ref_content, ref_title, ref_link), view=ref_view)
-  
+
 		await asyncio.sleep(timeout)
 		await bot_message.edit(view=None)
-  
+
 def prettify(content, page_title, link):
-	
+
 	content = content[0:4000] + ("..." if len(content) > 4000 else "")
 	page_title = page_title.replace("#","")
 	page_title = page_title.replace("\\","")
@@ -388,10 +388,10 @@ def prettify(content, page_title, link):
 	)
 	#embed.add_field(name="", value = link, inline = False)
 	embed.set_footer(text="BYOND Version 516.1645")
-	
+
 	return embed
 	# use: send(embed = prettify(content))
-	
+
 def get_page(item):
 	markdown_response = requests.get(f"{RAW}/{item}")
 	markdown_content = markdown_response.text
@@ -420,7 +420,7 @@ def fix_links(text) -> str:
 		path = text[start_index + len(start_marker):end_index]
 		new_link = f"]"
 		result.append(new_link)
-		
+
 		i = end_index + 1
 	return ''.join(result)
 
@@ -430,9 +430,9 @@ def cleanup_output(text):
 	text = text.replace("> [!TIP]", "")
 	text = text.replace("+  ", "-  ")
 	text = fix_links(text)
-	
+
 	text = text[0:text.find("> **See also:**")]
-	
+
 	return text
 
 bot.loop.create_task(periodic_commit_check())

--- a/ref_splitter.py
+++ b/ref_splitter.py
@@ -4,26 +4,26 @@ import pypandoc
 import cProfile
 
 """
- DM Reference Defucker 2000, by F0lak.
- 
- Here's my little script for splitting the DM Reference into markdown files
- 
- HOW TO USE:
-  All that you need to do is run the script
-  
- HOW IT WORKS:
-  The script finds info.dm in the same folder as this script
-  First it splits the html file into a list of strings using horizontal rules (<hr>) as the delimiter
-  It loops through all of the strings and does the following:
-  - parses the file names and relative paths from the string
-  - cleans up the file path and file names to prep for writing to disk
-  - reformats the strings from html to markdown
-  - cleans up the markdown for display on github.com
-  - writes the files to disk, mimicking the tree that the original reference uses
-  
-  After that, you're left with a big ol' tree of files that you can do what you want with.
-	
- (I'm a humble cook, not a programmer, so my apologies if the code isn't up to snuff!)
+DM Reference Defucker 2000, by F0lak.
+
+Here's my little script for splitting the DM Reference into markdown files
+
+HOW TO USE:
+	All that you need to do is run the script
+
+HOW IT WORKS:
+	The script finds info.dm in the same folder as this script
+	First it splits the html file into a list of strings using horizontal rules (<hr>) as the delimiter
+	It loops through all of the strings and does the following:
+	- parses the file names and relative paths from the string
+	- cleans up the file path and file names to prep for writing to disk
+	- reformats the strings from html to markdown
+	- cleans up the markdown for display on github.com
+	- writes the files to disk, mimicking the tree that the original reference uses
+
+	After that, you're left with a big ol' tree of files that you can do what you want with.
+
+(I'm a humble cook, not a programmer, so my apologies if the code isn't up to snuff!)
 """
 
 BUILD_HTML : bool = False
@@ -49,8 +49,8 @@ def write_file(text, file_name) -> None:
 	'''
 	output_file = os.path.join(f'{file_name}')
 	with open(output_file, 'w', encoding='utf-8') as file:
-		file.write(text)  
-  
+		file.write(text)
+
 def clean_file(file_name) -> None:
 	'''
 		Checks if a file exists and runs a markdown cleanup on it
@@ -62,7 +62,7 @@ def clean_file(file_name) -> None:
 			file.seek(0)
 			file.write(file_text)
 			file.truncate()
-   
+
 def clean_subdirectories(root_dir) -> None:
 	'''
 		Organizes the file and folder tree to mimic the BYOND reference
@@ -77,15 +77,15 @@ def clean_directory(directory) -> None:
 	'''
 	items = os.listdir(directory)
 	files = [file for file in items if os.path.exists(os.path.join(directory, file))]
-	
+
 	if len(files) == 1:
 		file_to_move = os.path.join(directory, files[0])
 		parent_dir = os.path.dirname(directory)
 		shutil.move(file_to_move, parent_dir)
-		
+
 		if not os.listdir(directory):
 			os.rmdir(directory)
-	
+
 	elif len(files) == 0:
 		os.rmdir(directory)
 
@@ -106,7 +106,7 @@ def build_file_tree() -> None:
 	'''
 	print("Building file tree")
 	for html_text in parts:
-		
+
 		md_text = pypandoc.convert_text(prep_html_file(html_text), "md", format="html")
 		md_title = clean_filenames(set_title(md_text, "md"))
 		html_title = clean_filenames(set_title(html_text, "html"))
@@ -126,13 +126,13 @@ def build_file_tree() -> None:
 
 			link_dict[f"{dirty_file_path}/{md_title}"] = f"{pruned_file_path}\\{md_title}.md"
 			pages.append(Page(f"{markdown_directory}\\{pruned_file_path}", f"{md_title}", "md", md_text))
-			
+
 			if BUILD_HTML == True:
 				pages.append(Page(f"{html_directory}\\html\\{pruned_file_path}", f"{md_title}", "html", html_text))
 
 				global index
 				index += f"<a href = \"html\\{pruned_file_path}\\{md_title}.html\">{md_title}</a></ br>\n"
- 
+
 def clean_markdown_files() -> list:
 	'''
 		Cleans up the formatting on every markdown file.
@@ -165,7 +165,7 @@ def copytext(text, start_delimiter, end_delimiter, start_closer="") -> str:
 		return text
 	else:
 		return ""
- 
+
 def set_title(text, extension) -> str | None:
 	'''
 		Sets the title of the file, based on the extension, using some data in the file to generate the filename
@@ -187,7 +187,7 @@ def set_title(text, extension) -> str | None:
 	else:
 		return None
 
-def clean_filenames(text) -> str: 
+def clean_filenames(text) -> str:
 	'''
 		Strips illegal characters from file names
 		Also performs minor cleanup of the file name
@@ -223,13 +223,13 @@ def clean_filenames(text) -> str:
 			text = text.replace(text[start_index:end_index], "")
 
 	return text
-   
+
 def clean_markdown_file(text) -> str:
 	'''
 		Cleans up and finalizes the formatting of markdown files
 	'''
 	# Most of these are leftovers from pypandoc's parsing
- 
+
 	if BUILD_FILE_TREE:
 		text = clean_empty_lines(text)
 		text = move_see_also(text)
@@ -254,7 +254,7 @@ def clean_markdown_file(text) -> str:
 		text = text.replace("\]", "]")
 		text = text.replace("\*", "*")
 	return text
-  
+
 def clean_empty_lines(text) -> str:
 	'''
 		Removes empty lines
@@ -290,9 +290,9 @@ def fix_links(text) -> str:
 		else:
 			new_link = f"](/ref/{path}.md) "
 		result.append(new_link)
-		
+
 		i = end_index + 1
-	
+
 	return ''.join(result)
 
 def clean_version(text) -> str:
@@ -326,7 +326,7 @@ def clean_inline_code(text) -> str:
 				if text[close_bracket_index+1:close_bracket_index+2] == '(':
 					close_paren_index = text.find(')', close_bracket_index)
 					code_index = close_paren_index + 1
-					
+
 					if text[code_index:code_index+7] == '{.code}':
 						link_name = text[close_bracket_index+2:close_paren_index]
 						fixed_text += f'[`{path}`]({link_name})'
@@ -356,25 +356,25 @@ def move_see_also(text) -> str:
 		tiptext = replacement_text.replace("\n", "\n> ")
 		if replacement_text:
 			text = text.replace(replacement_text, "") + f"\n\n> [!TIP] \n> {tiptext}"
-  
+
 	return text
-        
+
 def prep_html_file(text) -> str:
 	'''
 		Preps an html file for conversion to markdown by converting tags that would otherwise be
-  		stripped into tokens that will not be removed during conversion
+		stripped into tokens that will not be removed during conversion
 	'''
 	text = text.replace("<p>", "PARAGRAPH")
 	text = text.replace("<xmp>", "CODE_TICKS_DM")
 	text = text.replace("</xmp>", "CODE_TICKS")
 	text = text.replace("<p class=note>", "NOTE")
 	return text
-  
+
 class Page:
 	'''
 		Page object that represents a new file to be written to disk
 	'''
-	def __init__ (self, path, title, extension, text): 
+	def __init__ (self, path, title, extension, text):
 		self.title: str = title
 		self.path: str = path
 		self.text: str = text
@@ -389,11 +389,11 @@ class Page:
 	def add_to_index(self) -> None:
 		global index
 		index += f"<a href = \"f\"{self.path}\\{self.title}.{self.extension}\"{self.title}</a></ br>\n"
-        
+
 if __name__ == "__main__":
 	profiler = cProfile.Profile()
 	profiler.enable()
-    
+
 	script_directory = os.path.dirname(os.path.abspath(__file__))
 	input_file = os.path.join(script_directory, SOURCE_FILE)
 	markdown_directory = os.path.join(script_directory) + "\\ref"
@@ -408,7 +408,7 @@ if __name__ == "__main__":
 		link_dict	: dict = {}
 		pages	: list = []
 		index	: str = ""
-	
+
 		if os.path.exists("index.html"):
 			os.remove("index.html")
 
@@ -421,11 +421,10 @@ if __name__ == "__main__":
 		build_file_tree()
 
 		make_files()
-  
+
 	clean_markdown_files()
 
 	print("All done")
- 
+
 	profiler.disable()
 	profiler.dump_stats("profile.prof")
-		


### PR DESCRIPTION
Remove all trailing whitespace, primarily between code sections.
Tidy up indentation of multi-line comments, unifying indentation style to tabs.

The trailing whitespace and final newlines change is done via native VSCode functionality when the following config file is used:
`.vscode/config.json`
```json
{
    "files.trimFinalNewlines": true,
    "files.trimTrailingWhitespace": true
}
```

Multiline comments were brought to the common indentation style manually.

### Code style suggestions
In case you are using VSCode and want to use it as a primary editor for the repo, I can commit the configuration above in a separate PR. This will automatically trim redundant whitespace on file save.

Alternatively, an [.editorconfig](https://editorconfig.org/) file may be used to guide contributors towards common indentation style. I can prepare one if needed.
Editorconfig is supported natively or via extensions by many common developer-oriented editors, but is also just a good single source of truth for code style. It is then up to developer which tools he prefers to use to conform to the style.

Yet another alternative is to leave the indentation alone and just manually tweak it as needed.
Good option in case you don't want to pollute the repo with extra configuration/tools files that are not directly relevant to the oref itself. It's just two python files after all.