### PR TITLE
Update proc.md to specify global definition for procs

### DIFF
--- a/ref/world/proc.md
+++ b/ref/world/proc.md
@@ -1,5 +1,6 @@
 ## procs (world)
 
+New procs and vars cannot be defined under /world.  Define them globally instead.
 
 Built-in world procs:
 world/proc


### PR DESCRIPTION
Clarified that new procs and vars should be defined globally instead of under /world.